### PR TITLE
Tweaks to python-mode setup.

### DIFF
--- a/dot/.emacs.d/init.el
+++ b/dot/.emacs.d/init.el
@@ -210,6 +210,8 @@
 
 (require 'smartparens-config)
 (smartparens-global-mode 1)
+(setq sp-autoescape-string-quote-if-empty '(python-mode))
+
 (define-key sp-keymap (kbd "C-M-f") 'sp-forward-sexp)
 (define-key sp-keymap (kbd "C-M-b") 'sp-backward-sexp)
 (define-key sp-keymap (kbd "C-M-n") 'sp-next-sexp)

--- a/dot/.emacs.d/init.el
+++ b/dot/.emacs.d/init.el
@@ -279,6 +279,13 @@
           ) ; M-. and M-,
 
 ;;
+;; line numbering
+;;
+(require 'linum)
+(global-linum-mode t)
+
+
+;;
 ;; w3m
 ;;
 ;(setq browse-url-browser-function 'w3m-browse-url)

--- a/dot/.emacs.d/init.el
+++ b/dot/.emacs.d/init.el
@@ -274,7 +274,9 @@
             (setq jedi:complete-on-dot t)
             (local-set-key "\C-c\C-d" 'jedi:show-doc)
             (local-set-key (kbd "M-SPC") 'jedi:complete)
-            (setq jedi:use-shortcuts t))) ; M-. and M-,
+            (setq jedi:use-shortcuts t)
+            (setq show-trailing-whitespace t))
+          ) ; M-. and M-,
 
 ;;
 ;; w3m


### PR DESCRIPTION
Three changes;

– disable quote escaping inside empty strings in python-mode
– show unnecessary trailing whitespace at the end of statements in python-mode
– global line number mode (I like this for stack traces)